### PR TITLE
[오강산] 정렬 구현 #2

### DIFF
--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -1,16 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
-import { fetchGetOrderList, orderApiQueryKey } from "../services/order";
+import {
+  fetchGetOrderList,
+  orderApiQueryKey,
+  SortType,
+} from "../services/order";
 import PaginationButtons from "./OrderTable.PaginationButtons";
 import Table from "./common/Table";
 
 export default function OrderTable() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const page = searchParams.get(orderApiQueryKey.PAGE);
   const date = searchParams.get(orderApiQueryKey.DATE);
+  const sort = searchParams.get(orderApiQueryKey.SORT) as SortType;
+
   const { data, isSuccess } = useQuery(
-    ["order", page],
-    () => fetchGetOrderList({ page, date }),
+    ["order", page, date, sort],
+    () => fetchGetOrderList({ page, date, sort }),
     {
       select: (res) => {
         const totalCount = res.headers["x-total-count"];
@@ -30,12 +36,24 @@ export default function OrderTable() {
   }));
 
   const headerRows = [
-    "주문번호",
-    "거래시간",
-    "주문처리상태",
-    "고객번호",
-    "고객이름",
-    "가격",
+    {
+      title: "주문번호",
+      callback: () => {
+        searchParams.set(orderApiQueryKey.SORT, "id");
+        setSearchParams(searchParams);
+      },
+    },
+    {
+      title: "거래시간",
+      callback: () => {
+        searchParams.set(orderApiQueryKey.SORT, "time");
+        setSearchParams(searchParams);
+      },
+    },
+    { title: "주문처리상태" },
+    { title: "고객번호" },
+    { title: "고객이름" },
+    { title: "가격" },
   ];
 
   return (

--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -39,15 +39,31 @@ export default function OrderTable() {
     {
       title: "주문번호",
       callback: () => {
-        searchParams.set(orderApiQueryKey.SORT, "id");
-        setSearchParams(searchParams);
+        if (sort === "ID_DES") {
+          searchParams.set(orderApiQueryKey.SORT, "ID_ASC");
+          setSearchParams(searchParams);
+        } else if (sort === "ID_ASC") {
+          searchParams.delete(orderApiQueryKey.SORT);
+          setSearchParams(searchParams);
+        } else {
+          searchParams.set(orderApiQueryKey.SORT, "ID_DES");
+          setSearchParams(searchParams);
+        }
       },
     },
     {
       title: "거래시간",
       callback: () => {
-        searchParams.set(orderApiQueryKey.SORT, "time");
-        setSearchParams(searchParams);
+        if (sort === "TIME_DES") {
+          searchParams.set(orderApiQueryKey.SORT, "TIME_ASC");
+          setSearchParams(searchParams);
+        } else if (sort == "TIME_ASC") {
+          searchParams.delete(orderApiQueryKey.SORT);
+          setSearchParams(searchParams);
+        } else {
+          searchParams.set(orderApiQueryKey.SORT, "TIME_DES");
+          setSearchParams(searchParams);
+        }
       },
     },
     { title: "주문처리상태" },

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -3,14 +3,16 @@ export default function Table({
   headerRows,
 }: {
   bodyRows: { key: string }[];
-  headerRows: string[];
+  headerRows: { title: string; callback?: VoidFunction }[];
 }) {
   return (
     <table>
       <thead>
         <tr>
-          {headerRows.map((title, i) => (
-            <th key={title + i}>{title}</th>
+          {headerRows.map(({ title, callback }, i) => (
+            <th key={title + i} onClick={callback}>
+              {title}
+            </th>
           ))}
         </tr>
       </thead>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -37,13 +37,21 @@ export const handlers = [
           );
 
     const sortData = (origin: typeof mockdata) =>
-      sort === "id"
+      sort === "ID_DES"
         ? origin.sort((a, b) => b.id - a.id)
-        : sort === "time"
+        : sort === "ID_ASC"
+        ? origin.sort((a, b) => a.id - b.id)
+        : sort === "TIME_DES"
         ? origin.sort(
             (a, b) =>
               new Date(b.transaction_time).getTime() -
               new Date(a.transaction_time).getTime()
+          )
+        : sort === "TIME_ASC"
+        ? origin.sort(
+            (a, b) =>
+              new Date(a.transaction_time).getTime() -
+              new Date(b.transaction_time).getTime()
           )
         : origin;
 

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -9,7 +9,7 @@ export type OrderProps = {
   currency: string; // ex) $20.42
 };
 
-type GetOrderListResponse = OrderProps[];
+export type SortType = "id" | "time" | null;
 
 export const orderApiUrls = {
   ORDER: "/api/order",
@@ -18,6 +18,7 @@ export const orderApiUrls = {
 export const orderApiQueryKey = {
   PAGE: "page",
   DATE: "date",
+  SORT: "sort",
 };
 
 // 과제 요구사항에 따른 페이지당 데이터 개수
@@ -29,13 +30,15 @@ export const TODAY = "2023-03-08";
 export const fetchGetOrderList = ({
   page,
   date,
+  sort,
 }: {
   page: string | null;
   date: string | null;
+  sort: SortType;
 }) => {
-  return axios.get<GetOrderListResponse>(
+  return axios.get<OrderProps[]>(
     `${orderApiUrls.ORDER}?${orderApiQueryKey.PAGE}=${page ?? "1"}&${
       orderApiQueryKey.DATE
-    }=${date ?? TODAY}`
+    }=${date ?? TODAY}&${orderApiQueryKey.SORT}=${sort}`
   );
 };

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -9,7 +9,7 @@ export type OrderProps = {
   currency: string; // ex) $20.42
 };
 
-export type SortType = "id" | "time" | null;
+export type SortType = "ID_DES" | "ID_ASC" | "TIME_DES" | "TIME_ASC" | null;
 
 export const orderApiUrls = {
   ORDER: "/api/order",


### PR DESCRIPTION
이슈 번호 #2
## Todo

2. 정렬 기능을 구현해주세요
    - 기본 정렬은 ID 기준 오름차순으로 구현해주세요
    - 표에서 `주문번호`, `거래일 & 거래시간` 버튼을 누르면 각각 내림차순 정렬이 되도록 해주세요

## 주안점
[배포 링크](https://shop-admin-page.vercel.app/)

### 직관적인 정렬 UX | 클릭 반복에 따른 재정렬
- 과제 요구사항에 따라 한 번 클릭 시 내림차순으로 정렬되지만 직관적 사용을 위해 반복 클릭에 따른 재정렬 구현
  - 한 번 클릭 : 내림차순 정렬
  - 두 번 클릭 : 오름차순 정렬
  - 세 번 클릭 : 원상복구
  - 반복